### PR TITLE
feat: 관리자 블로그 삭제 기능 구현

### DIFF
--- a/admin/src/main/java/itcast/application/AdminBlogService.java
+++ b/admin/src/main/java/itcast/application/AdminBlogService.java
@@ -27,9 +27,18 @@ public class AdminBlogService {
         return new AdminBlogResponse(savedBlogs);
     }
 
+    public AdminBlogResponse deleteBlog(Long userId, Long blogId) {
+        isAdmin(userId);
+        Blog blog = blogRepository.findById(blogId).orElseThrow(()->
+                new IdNotFoundException("해당 블로그가 존재하지 않습니다"));
+        blogRepository.delete(blog);
+
+        return new AdminBlogResponse(blog);
+    }
+
     private void isAdmin(Long id){
         User user = userRepository.findById(id).orElseThrow(()->
-                new IdNotFoundException("해당 유저 id가 존재하지 않습니다."));
+                new IdNotFoundException("해당 유저가 존재하지 않습니다."));
         String email = user.getKakaoEmail();
         if(!adminRepository.existsByEmail(email)){
             throw new NotAdminException("접근할 수 없는 유저입니다.");

--- a/admin/src/main/java/itcast/controller/AdminBlogController.java
+++ b/admin/src/main/java/itcast/controller/AdminBlogController.java
@@ -10,17 +10,23 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
+@RequestMapping("/api/blog")
 public class AdminBlogController {
 
-    private final AdminBlogService adminService;
+    private final AdminBlogService adminBlogService;
 
-    @PostMapping("/blogs")
+    @PostMapping
     public ResponseTemplate<AdminBlogResponse> createBlog(
             @RequestParam Long userId,
             @RequestBody AdminBlogRequest adminBlogRequest
     ) {
-        AdminBlogResponse response = adminService.createBlog(userId, adminBlogRequest.toEntity(adminBlogRequest));
+        AdminBlogResponse response = adminBlogService.createBlog(userId, adminBlogRequest.toEntity(adminBlogRequest));
         return new ResponseTemplate<>(HttpStatus.CREATED, "관리자 블로그 생성 성공", response);
+    }
+
+    @DeleteMapping
+    public ResponseTemplate<AdminBlogResponse> deleteBlog(@RequestParam Long userId, @RequestParam Long blogId) {
+        AdminBlogResponse response = adminBlogService.deleteBlog(userId, blogId);
+        return new ResponseTemplate<>(HttpStatus.OK, "관리자 블로그 삭제 성공", response);
     }
 }

--- a/admin/src/main/java/itcast/dto/request/AdminBlogRequest.java
+++ b/admin/src/main/java/itcast/dto/request/AdminBlogRequest.java
@@ -20,7 +20,7 @@ public record AdminBlogRequest (
         LocalDateTime sendAt
 ){
     public static Blog toEntity(AdminBlogRequest adminBlogRequest) {
-        return Blog.builder()
+        return Blog.adminBuilder()
                 .platform(adminBlogRequest.platform())
                 .title(adminBlogRequest.title())
                 .content(adminBlogRequest.content())

--- a/admin/src/test/java/itcast/AdminBlogServiceTest.java
+++ b/admin/src/test/java/itcast/AdminBlogServiceTest.java
@@ -1,0 +1,75 @@
+package itcast;
+
+import itcast.application.AdminBlogService;
+import itcast.domain.blog.Blog;
+import itcast.domain.blog.enums.BlogStatus;
+import itcast.domain.blog.enums.Platform;
+import itcast.domain.user.User;
+import itcast.domain.user.enums.Interest;
+import itcast.dto.request.AdminBlogRequest;
+import itcast.dto.response.AdminBlogResponse;
+import itcast.repository.AdminRepository;
+import itcast.repository.BlogRepository;
+import itcast.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class AdminBlogServiceTest {
+    @Mock
+    private BlogRepository blogRepository;
+    @Mock
+    private AdminRepository adminRepository;
+    @Mock
+    private UserRepository userRepository;
+    @InjectMocks
+    private AdminBlogService adminBlogService;
+
+    @Test
+    @DisplayName("블로그 삭제 성공")
+    public void successBlogDelete(){
+        //Given
+        Long userId = 1L;
+        Long blogId = 1L;
+
+        User adminUser = User.builder()
+                .id(userId)
+                .kakaoEmail("admin@kakao.com")
+                .build();
+
+        Blog blog = Blog.adminBuilder()
+                .id(1L)
+                .title("테스트 블로그")
+                .content("테스트 내용")
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(adminUser));
+        given(adminRepository.existsByEmail(adminUser.getKakaoEmail())).willReturn(true);
+        given(blogRepository.findById(blogId)).willReturn(Optional.of(blog));
+
+        // When
+        AdminBlogResponse response = adminBlogService.deleteBlog(userId, blogId);
+
+        // Then
+        assertEquals(blog.getId(), response.id());
+        assertEquals(blog.getTitle(), response.title());
+        verify(blogRepository).delete(blog);
+    }
+}

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -10,11 +10,11 @@ repositories {
 }
 
 tasks.bootJar {
-    enabled = true
+    enabled = false
 }
 
 tasks.jar {
-    enabled = false
+    enabled = true
 }
 
 dependencies {

--- a/common/src/main/java/itcast/domain/blog/Blog.java
+++ b/common/src/main/java/itcast/domain/blog/Blog.java
@@ -78,9 +78,20 @@ public class Blog extends BaseEntity {
         this.status = status;
     }
 
-    @Builder
-    public Blog(Platform platform, String title, String content, String originalContent, Interest interest,
-                LocalDateTime publishedAt, int rating, String link, String thumbnail, BlogStatus status, LocalDateTime sendAt) {
+    @Builder(builderClassName = "adminBuilder", builderMethodName = "adminBuilder")
+    public Blog(Long id,
+                Platform platform,
+                String title,
+                String content,
+                String originalContent,
+                Interest interest,
+                LocalDateTime publishedAt,
+                int rating,
+                String link,
+                String thumbnail,
+                BlogStatus status,
+                LocalDateTime sendAt) {
+        this.id = id;
         this.platform = platform;
         this.title = title;
         this.content = content;


### PR DESCRIPTION
## 🔎 작업 내용
- 관리자가 DB에 저장된 블로그를 삭제하도록 기능 추가

## ➕ 이슈 링크
- #49 

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/3c5674e9-f934-4678-8168-1c3659d2feb5)

## 🧑‍💻 예정 작업
- 인증 추가하여 admin 페이지 수정
## 📝 체크리스트
- [x] 브랜치 이름은 `issue/이슈번호` 형식으로 작성했는가?
- [x] 커밋 메시지는 `[#이슈번호] Feat: 커밋 내용` 형식으로 작성했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?