### PR TITLE
fix: 블로그 크롤링 시 일부 데이터만 가져오는 에러 해결

### DIFF
--- a/schedule/src/main/java/itcast/blog/application/YozmCrawlingService.java
+++ b/schedule/src/main/java/itcast/blog/application/YozmCrawlingService.java
@@ -34,8 +34,6 @@ public class YozmCrawlingService {
         blogs.forEach(blog -> {
                     Blog originalBlog = Blog.createYozmBlog(blog.getTitle(), blog.getOriginalContent(), blog.getPublishedAt(),
                             blog.getLink(), blog.getThumbnail());
-                    log.info("title: {}", blog.getTitle());
-                    log.info("href: {}",  blog.getLink());
                     Blog savedId = blogRepository.save(originalBlog);
                     Message message = new Message("user", blog.getOriginalContent());
                     GPTSummaryRequest request = new GPTSummaryRequest("gpt-4o-mini", message, 0.7f);

--- a/schedule/src/main/java/itcast/blog/parser/VelogDataParser.java
+++ b/schedule/src/main/java/itcast/blog/parser/VelogDataParser.java
@@ -45,7 +45,7 @@ public class VelogDataParser {
 
                         final String title = Objects.requireNonNull(document).title();
                         final String thumbnail = document.selectFirst("meta[property=og:image]").attr("content");
-                        final String content = document.select("div.sc-eGRUor.gdnhbG.atom-one").text();
+                        final String content = document.select("div[class^=sc-][class$=atom-one]").text();
                         final String publishedAt = document.select(".information").eq(3).text();
 
                         log.info("title: {}", title);

--- a/schedule/src/main/java/itcast/blog/parser/VelogDataParser.java
+++ b/schedule/src/main/java/itcast/blog/parser/VelogDataParser.java
@@ -8,14 +8,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.jsoup.nodes.Document;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.IntStream;
 
 @Slf4j
-@Configuration
+@Component
 @RequiredArgsConstructor
 public class VelogDataParser {
 

--- a/schedule/src/main/java/itcast/blog/parser/VelogDataParser.java
+++ b/schedule/src/main/java/itcast/blog/parser/VelogDataParser.java
@@ -2,7 +2,9 @@ package itcast.blog.parser;
 
 import itcast.blog.client.JsoupCrawler;
 import itcast.domain.blog.Blog;
+
 import java.time.LocalDateTime;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONArray;
@@ -25,38 +27,32 @@ public class VelogDataParser {
         final JSONObject jsonObject = new JSONObject(jsonResponse);
         final JSONArray trendingPosts = jsonObject.getJSONObject("data").getJSONArray("trendingPosts");
 
-        return IntStream.range(0, trendingPosts.length())
-                .mapToObj(trendingPosts::getJSONObject)
-                .map(post -> {
-                    final String username = post.getJSONObject("user").getString("username");
-                    final String urlSlug = post.getString("url_slug");
-                    return "https://velog.io/@" + username + "/" + urlSlug; // BLOG URL
-                })
-                .toList();
+        return IntStream.range(0, trendingPosts.length()).mapToObj(trendingPosts::getJSONObject).map(post -> {
+            final String username = post.getJSONObject("user").getString("username");
+            final String urlSlug = post.getString("url_slug");
+            return "https://velog.io/@" + username + "/" + urlSlug; // BLOG URL
+        }).toList();
     }
 
     public List<Blog> parseTrendingPosts(final List<String> blogUrl) {
         final LocalDateTime DEFAULT_PUBLISHED_AT = LocalDateTime.of(2024, 12, 12, 12, 12, 12);
 
-        return blogUrl.stream()
-                .map(url -> {
-                    try {
-                        final Document document = jsoupCrawler.getHtmlDocumentOrNull(url);
+        return blogUrl.stream().map(url -> {
+            try {
+                final Document document = jsoupCrawler.getHtmlDocumentOrNull(url);
 
-                        final String title = Objects.requireNonNull(document).title();
-                        final String thumbnail = document.selectFirst("meta[property=og:image]").attr("content");
-                        final String content = document.select("div[class^=sc-][class$=atom-one]").text();
-                        final String publishedAt = document.select(".information").eq(3).text();
+                final String title = Objects.requireNonNull(document).title();
+                final String thumbnail = document.selectFirst("meta[property=og:image]").attr("content");
+                final String content = document.select("div[class^=sc-][class$=atom-one]").text();
+                final String publishedAt = document.select(".information").eq(3).text();
 
-                        log.info("title: {}", title);
+                log.info("title: {}", title);
 
-                        return Blog.createVelogBlog(title, content, DEFAULT_PUBLISHED_AT, url, thumbnail);
-                    } catch (Exception e) {
-                        log.error("Error", e);
-                        return null;
-                    }
-                })
-                .filter(Objects::nonNull)
-                .toList();
+                return Blog.createVelogBlog(title, content, DEFAULT_PUBLISHED_AT, url, thumbnail);
+            } catch (Exception e) {
+                log.error("Error", e);
+                return null;
+            }
+        }).filter(Objects::nonNull).toList();
     }
 }

--- a/schedule/src/main/java/itcast/blog/parser/VelogDataParser.java
+++ b/schedule/src/main/java/itcast/blog/parser/VelogDataParser.java
@@ -37,22 +37,23 @@ public class VelogDataParser {
     public List<Blog> parseTrendingPosts(final List<String> blogUrl) {
         final LocalDateTime DEFAULT_PUBLISHED_AT = LocalDateTime.of(2024, 12, 12, 12, 12, 12);
 
-        return blogUrl.stream().map(url -> {
-            try {
-                final Document document = jsoupCrawler.getHtmlDocumentOrNull(url);
+        return blogUrl.stream()
+                .map(url -> {
+                    try {
+                        final Document document = jsoupCrawler.getHtmlDocumentOrNull(url);
 
-                final String title = Objects.requireNonNull(document).title();
-                final String thumbnail = document.selectFirst("meta[property=og:image]").attr("content");
-                final String content = document.select("div[class^=sc-][class$=atom-one]").text();
-                final String publishedAt = document.select(".information").eq(3).text();
+                        final String title = Objects.requireNonNull(document).title();
+                        final String thumbnail = document.selectFirst("meta[property=og:image]").attr("content");
+                        final String content = document.select("div[class^=sc-][class$=atom-one]").text();
+                        final String publishedAt = document.select(".information").eq(3).text();
 
-                log.info("title: {}", title);
+                        log.info("title: {}", title);
 
-                return Blog.createVelogBlog(title, content, DEFAULT_PUBLISHED_AT, url, thumbnail);
-            } catch (Exception e) {
-                log.error("Error", e);
-                return null;
-            }
-        }).filter(Objects::nonNull).toList();
+                        return Blog.createVelogBlog(title, content, DEFAULT_PUBLISHED_AT, url, thumbnail);
+                    } catch (Exception e) {
+                        log.error("Error", e);
+                        return null;
+                    }
+                }).filter(Objects::nonNull).toList();
     }
 }

--- a/schedule/src/main/java/itcast/blog/parser/YozmDataParser.java
+++ b/schedule/src/main/java/itcast/blog/parser/YozmDataParser.java
@@ -6,14 +6,15 @@ import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.nodes.Document;
-import org.springframework.context.annotation.Configuration;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.IntStream;
 
 @Slf4j
-@Configuration
+@Component
 @RequiredArgsConstructor
 public class YozmDataParser {
 
@@ -28,6 +29,7 @@ public class YozmDataParser {
                 .mapToObj(pageNum -> BASE_URL + pageNum + SORTED_URL)
                 .map(jsoupCrawler::getHtmlDocumentOrNull).filter(Objects::nonNull)
                 .map(doc -> doc.select("a.item-title.link-text.link-underline.text900"))
+                .flatMap(Elements::stream)
                 .map(link -> link.attr("abs:href"))
                 .toList();
     }
@@ -35,16 +37,17 @@ public class YozmDataParser {
     public List<Blog> parseTrendingPosts(List<String> blogUrls) {
         final LocalDateTime DEFAULT_PUBLISHED_AT = LocalDateTime.of(2024, 12, 12, 12, 12, 12);
         return blogUrls.stream()
-                .map(href -> {
-                    Document document = jsoupCrawler.getHtmlDocumentOrNull(href);
+                .map(url -> {
+                    Document document = jsoupCrawler.getHtmlDocumentOrNull(url);
                     String title = Objects.requireNonNull(document).title();
                     String thumbnail = document.selectFirst("meta[property=og:image]").attr("content");
                     String content = document.select("div.next-news-contents").text();
                     String publishedDate = document.select("div.content-meta-elem").eq(5).text();
 
                     log.info("title: {}", title);
-                    return Blog.createYozmBlog(title, content, DEFAULT_PUBLISHED_AT, href, thumbnail);
+                    return Blog.createYozmBlog(title, content, DEFAULT_PUBLISHED_AT, url, thumbnail);
                 })
+                .filter(Objects::nonNull)
                 .toList();
     }
 }

--- a/schedule/src/main/java/itcast/blog/parser/YozmDataParser.java
+++ b/schedule/src/main/java/itcast/blog/parser/YozmDataParser.java
@@ -2,7 +2,9 @@ package itcast.blog.parser;
 
 import itcast.blog.client.JsoupCrawler;
 import itcast.domain.blog.Blog;
+
 import java.time.LocalDateTime;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.nodes.Document;

--- a/schedule/src/main/java/itcast/news/application/NewsService.java
+++ b/schedule/src/main/java/itcast/news/application/NewsService.java
@@ -31,9 +31,7 @@ public class NewsService {
     private static final int YESTERDAY = 2;
     private static final int ALARM_HOUR = 7;
     private static final int ALARM_DAY = 2;
-
-    @Value("${scheduler.cron.crawling}")
-    private String url;
+    private static final String url = "https://news.naver.com/breakingnews/section/105/283";
 
     private final NewsRepository newsRepository;
     private final GPTService gptService;


### PR DESCRIPTION
## 🔎 작업 내용
- Yozm: `.flatMap(Elements::stream)` 추가 후 해결
- Velog: 매번 div의 class 속성이 달라져서 `div[class^=sc-][class$=atom-one]` 이렇게 앞 뒤 공통 부분으로 select 하도록 수정 후 해결

## ➕ 이슈 링크
- #56 

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/cee4d577-25bc-4aac-85b1-d1d5b2f8f271)

## 🧑‍💻 예정 작업
- 선택 스케쥴러 PR 작성
## 📝 체크리스트
- [x] 브랜치 이름은 `issue/이슈번호` 형식으로 작성했는가?
- [x] 커밋 메시지는 `[#이슈번호] Feat: 커밋 내용` 형식으로 작성했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [x] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [ ] 테스트 코드를 작성했는가?