### PR TITLE
feat: 관리자 블로그 히스토리 조회

### DIFF
--- a/admin/src/main/java/itcast/application/AdminBlogHistoryService.java
+++ b/admin/src/main/java/itcast/application/AdminBlogHistoryService.java
@@ -1,0 +1,42 @@
+package itcast.application;
+
+import itcast.domain.user.User;
+import itcast.dto.response.AdminBlogHistoryResponse;
+import itcast.exception.ErrorCodes;
+import itcast.exception.ItCastApplicationException;
+import itcast.jwt.repository.UserRepository;
+import itcast.repository.AdminRepository;
+import itcast.repository.BlogHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class AdminBlogHistoryService {
+
+    private final UserRepository userRepository;
+    private final AdminRepository adminRepository;
+    private final BlogHistoryRepository blogHistoryRepository;
+
+    public Page<AdminBlogHistoryResponse> retrieveBlogHistory(Long adminId, Long userId, Long blogId, LocalDate createdAt,
+                                                              int page, int size
+    ) {
+        isAdmin(adminId);
+        Pageable pageable = PageRequest.of(page, size);
+        return blogHistoryRepository.findBlogHistoryListByCondition(userId, blogId, createdAt, pageable);
+    }
+
+    private void isAdmin(Long id) {
+        User user = userRepository.findById(id).orElseThrow(() ->
+                new ItCastApplicationException(ErrorCodes.USER_NOT_FOUND));
+        String email = user.getKakaoEmail();
+        if (!adminRepository.existsByEmail(email)) {
+            throw new ItCastApplicationException(ErrorCodes.INVALID_USER);
+        }
+    }
+}

--- a/admin/src/main/java/itcast/controller/AdminBlogHistoryController.java
+++ b/admin/src/main/java/itcast/controller/AdminBlogHistoryController.java
@@ -1,0 +1,46 @@
+package itcast.controller;
+
+import itcast.ResponseTemplate;
+import itcast.application.AdminBlogHistoryService;
+import itcast.dto.response.AdminBlogHistoryResponse;
+import itcast.dto.response.PageResponse;
+import itcast.jwt.CheckAuth;
+import itcast.jwt.LoginMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/blog-history")
+public class AdminBlogHistoryController {
+
+    private final AdminBlogHistoryService adminBlogHistoryService;
+
+    @CheckAuth
+    @GetMapping
+    public ResponseTemplate<PageResponse<AdminBlogHistoryResponse>> retrieveBlogHistory(
+            @LoginMember Long adminId,
+            @RequestParam(required = false) Long userId,
+            @RequestParam(required = false) Long blogId,
+            @RequestParam(required = false) LocalDate createdAt,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Page<AdminBlogHistoryResponse> blogHistoryPage = adminBlogHistoryService.retrieveBlogHistory(adminId, userId, blogId,
+                createdAt, page, size);
+        PageResponse<AdminBlogHistoryResponse> pageResponse = new PageResponse<>(
+                blogHistoryPage.getContent(),
+                blogHistoryPage.getNumber(),
+                blogHistoryPage.getSize(),
+                blogHistoryPage.getTotalPages()
+        );
+        return new ResponseTemplate<>(HttpStatus.OK, "관리자 블로그 히스토리 조회 성공", pageResponse);
+    }
+}

--- a/admin/src/main/java/itcast/dto/response/AdminBlogHistoryResponse.java
+++ b/admin/src/main/java/itcast/dto/response/AdminBlogHistoryResponse.java
@@ -1,0 +1,22 @@
+package itcast.dto.response;
+
+import itcast.domain.blogHistory.BlogHistory;
+import java.time.LocalDateTime;
+
+public record AdminBlogHistoryResponse (
+        Long id,
+        Long userId,
+        Long blogId,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt
+) {
+    public AdminBlogHistoryResponse(BlogHistory blogHistory) {
+        this(
+                blogHistory.getId(),
+                blogHistory.getUser().getId(),
+                blogHistory.getBlog().getId(),
+                blogHistory.getCreatedAt(),
+                blogHistory.getModifiedAt()
+        );
+    }
+}

--- a/admin/src/main/java/itcast/repository/BlogHistoryRepository.java
+++ b/admin/src/main/java/itcast/repository/BlogHistoryRepository.java
@@ -1,0 +1,7 @@
+package itcast.repository;
+
+import itcast.domain.blogHistory.BlogHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlogHistoryRepository extends JpaRepository<BlogHistory, Long>, CustomBlogHistoryRepository {
+}

--- a/admin/src/main/java/itcast/repository/CustomBlogHistoryRepository.java
+++ b/admin/src/main/java/itcast/repository/CustomBlogHistoryRepository.java
@@ -1,0 +1,11 @@
+package itcast.repository;
+
+import itcast.dto.response.AdminBlogHistoryResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+
+public interface CustomBlogHistoryRepository {
+    Page<AdminBlogHistoryResponse> findBlogHistoryListByCondition(Long userId, Long blogId, LocalDate createdAt, Pageable pageable);
+}

--- a/admin/src/main/java/itcast/repository/CustomBlogHistoryRepositoryImpl.java
+++ b/admin/src/main/java/itcast/repository/CustomBlogHistoryRepositoryImpl.java
@@ -1,0 +1,78 @@
+package itcast.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import itcast.domain.blogHistory.QBlogHistory;
+import itcast.dto.response.AdminBlogHistoryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import static itcast.domain.blogHistory.QBlogHistory.blogHistory;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomBlogHistoryRepositoryImpl implements CustomBlogHistoryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<AdminBlogHistoryResponse> findBlogHistoryListByCondition(Long userId, Long blogId, LocalDate createdAt, Pageable pageable) {
+        QBlogHistory blogHistory = QBlogHistory.blogHistory;
+
+        JPQLQuery<AdminBlogHistoryResponse> query = queryFactory
+                .select(Projections.constructor(AdminBlogHistoryResponse.class,
+                        blogHistory.id,
+                        blogHistory.user.id,
+                        blogHistory.blog.id,
+                        blogHistory.createdAt,
+                        blogHistory.modifiedAt
+                ))
+                .from(blogHistory)
+                .where(userIdEq(userId), blogIdEq(blogId), createdAtEq(createdAt))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        List<AdminBlogHistoryResponse> content = query.fetch();
+
+        JPQLQuery<Long> countQuery = queryFactory
+                .select(blogHistory.count())
+                .from(blogHistory)
+                .where(userIdEq(userId), blogIdEq(blogId), createdAtEq(createdAt));
+
+        return new PageImpl<>(content, pageable, countQuery.fetchOne());
+    }
+
+    private BooleanExpression userIdEq(Long userId) {
+        if(userId == null) {
+            return null;
+        }
+        return blogHistory.user.id.eq(userId);
+    }
+
+    private BooleanExpression blogIdEq(Long blogId) {
+        if(blogId == null) {
+            return null;
+        }
+        return blogHistory.blog.id.eq(blogId);
+    }
+
+    private BooleanExpression createdAtEq(LocalDate createdAt) {
+        if(createdAt == null) {
+            return null;
+        }
+
+        LocalDateTime startAt = LocalDateTime.of(createdAt, LocalTime.of(0,0,0));
+        LocalDateTime endAt = LocalDateTime.of(createdAt, LocalTime.of(23,59, 59));
+
+        return blogHistory.createdAt.between(startAt, endAt);
+    }
+}

--- a/admin/src/test/java/itcast/AdminBlogHistoryServiceTest.java
+++ b/admin/src/test/java/itcast/AdminBlogHistoryServiceTest.java
@@ -1,0 +1,51 @@
+package itcast;
+
+import itcast.application.AdminBlogHistoryService;
+import itcast.domain.blog.Blog;
+import itcast.domain.blogHistory.BlogHistory;
+import itcast.domain.user.User;
+import itcast.dto.response.AdminBlogHistoryResponse;
+import itcast.jwt.repository.UserRepository;
+import itcast.repository.BlogHistoryRepository;
+import itcast.repository.BlogRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Transactional
+@SpringBootTest(classes = AdminApplication.class)
+public class AdminBlogHistoryServiceTest {
+
+    @Autowired
+    BlogHistoryRepository blogHistoryRepository;
+
+    @Test
+    @DisplayName("블로그 히스토리 조회 성공")
+    public void SuccessBlogHistoryRetrieve() {
+        //given
+        Long userId = 1L;
+        Long blogId = null;
+        LocalDate createdAt = null;
+        int page = 0;
+        int size = 20;
+        Pageable pageable = PageRequest.of(page, size);
+
+        //when
+        Page<AdminBlogHistoryResponse> blogHistories = blogHistoryRepository.findBlogHistoryListByCondition(userId, blogId, createdAt, pageable);
+
+        //Then
+        assertNotNull(blogHistories);
+        assertFalse(blogHistories.isEmpty());
+        assertEquals(userId, blogHistories.getContent().get(0).userId());
+    }
+}

--- a/common/src/main/java/itcast/domain/blogHistory/BlogHistory.java
+++ b/common/src/main/java/itcast/domain/blogHistory/BlogHistory.java
@@ -3,13 +3,7 @@ package itcast.domain.blogHistory;
 import itcast.domain.BaseEntity;
 import itcast.domain.blog.Blog;
 import itcast.domain.user.User;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +11,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
+@Table(name = "blog_history", indexes = {@Index(name = "idx_user_news_created", columnList = "user_id, blog_id, created_at")})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BlogHistory extends BaseEntity {
 


### PR DESCRIPTION
## 🔎 작업 내용
- 블로그 히스토리를 blogId, userId, createdAt으로 조회(QueryDSL)
- 블로그 히스토리 테스트(더미데이터없이 기존의 데이터로)

## ➕ 이슈 링크
- #108 

## 📸 스크린샷(선택)
![블로그히스토리 조회캡](https://github.com/user-attachments/assets/d7548247-bb19-4717-a991-cfb46f7621d5)

## 🧑‍💻 예정 작업
-csv 다운로드 기능 추가
## 📝 체크리스트
- [x] 브랜치 이름은 `issue/이슈번호` 형식으로 작성했는가?
- [x] 커밋 메시지는 `[#이슈번호] Feat: 커밋 내용` 형식으로 작성했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?