### PR TITLE
refactor: 히스토리 테스트 Mock으로 변경

### DIFF
--- a/admin/src/test/java/itcast/AdminBlogHistoryServiceTest.java
+++ b/admin/src/test/java/itcast/AdminBlogHistoryServiceTest.java
@@ -1,51 +1,92 @@
 package itcast;
 
 import itcast.application.AdminBlogHistoryService;
-import itcast.domain.blog.Blog;
-import itcast.domain.blogHistory.BlogHistory;
 import itcast.domain.user.User;
 import itcast.dto.response.AdminBlogHistoryResponse;
 import itcast.jwt.repository.UserRepository;
+import itcast.repository.AdminRepository;
 import itcast.repository.BlogHistoryRepository;
-import itcast.repository.BlogRepository;
-import jakarta.transaction.Transactional;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
-@Transactional
-@SpringBootTest(classes = AdminApplication.class)
+@ExtendWith(MockitoExtension.class)
 public class AdminBlogHistoryServiceTest {
 
-    @Autowired
+    @Mock
     BlogHistoryRepository blogHistoryRepository;
+    @Mock
+    UserRepository userRepository;
+    @Mock
+    AdminRepository adminRepository;
+    @InjectMocks
+    AdminBlogHistoryService adminBlogHistoryService;
 
     @Test
     @DisplayName("블로그 히스토리 조회 성공")
     public void SuccessBlogHistoryRetrieve() {
         //given
         Long userId = 1L;
-        Long blogId = null;
-        LocalDate createdAt = null;
+        LocalDate testDate = LocalDate.of(2020, 1, 1);
+        LocalDateTime testAt01 = LocalDateTime.of(2025, 1, 1, 0, 0, 0);
+        LocalDateTime testAt02 = LocalDateTime.of(2025, 1, 1, 23, 59, 59);
         int page = 0;
         int size = 20;
+
+        User user = User.builder()
+                .id(1L)
+                .kakaoEmail("kakao@kakao.com")
+                .build();
+
+        List<AdminBlogHistoryResponse> responses = List.of(
+                new AdminBlogHistoryResponse(
+                        1L,
+                        1L,
+                        1L,
+                        testAt01,
+                        testAt01
+                ),
+                new AdminBlogHistoryResponse(
+                        2L,
+                        2L,
+                        1L,
+                        testAt02,
+                        testAt02
+                )
+        );
+
         Pageable pageable = PageRequest.of(page, size);
+        Page<AdminBlogHistoryResponse> blogHistoryPage = new PageImpl<>(responses, pageable, responses.size());
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(adminRepository.existsByEmail(user.getKakaoEmail())).willReturn(true);
+        given(blogHistoryRepository.findBlogHistoryListByCondition(null, 1L, testDate, pageable)).willReturn(blogHistoryPage);
 
         //when
-        Page<AdminBlogHistoryResponse> blogHistories = blogHistoryRepository.findBlogHistoryListByCondition(userId, blogId, createdAt, pageable);
+        Page<AdminBlogHistoryResponse> responsePage = adminBlogHistoryService.retrieveBlogHistory(userId, null, 1L, testDate, page, size);
 
-        //Then
-        assertNotNull(blogHistories);
-        assertFalse(blogHistories.isEmpty());
-        assertEquals(userId, blogHistories.getContent().get(0).userId());
+        //then
+        assertEquals(2, responsePage.getContent().size());
+        assertEquals(1L, responsePage.getContent().get(0).userId());
+        assertEquals(2L, responsePage.getContent().get(1).userId());
+        assertEquals(page, responsePage.getNumber());
+        assertEquals(size, responsePage.getSize());
+        verify(blogHistoryRepository).findBlogHistoryListByCondition(null, 1L, testDate, pageable);
     }
 }

--- a/admin/src/test/java/itcast/AdminNewsHistoryServiceTest.java
+++ b/admin/src/test/java/itcast/AdminNewsHistoryServiceTest.java
@@ -1,98 +1,90 @@
 package itcast;
 
-import itcast.domain.news.News;
-import itcast.domain.newsHistory.NewsHistory;
+import itcast.application.AdminNewsHistoryService;
 import itcast.domain.user.User;
 import itcast.dto.response.AdminNewsHistoryResponse;
 import itcast.jwt.repository.UserRepository;
+import itcast.repository.AdminRepository;
 import itcast.repository.NewsHistoryRepository;
-import itcast.repository.NewsRepository;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StopWatch;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
-@Transactional
-@SpringBootTest(classes = AdminApplication.class)
+@ExtendWith(MockitoExtension.class)
 public class AdminNewsHistoryServiceTest {
 
-    @Autowired
+    @Mock
     NewsHistoryRepository newsHistoryRepository;
-    @Autowired
+    @Mock
     UserRepository userRepository;
-    @Autowired
-    NewsRepository newsRepository;
-
-    @BeforeEach
-    @DisplayName("10만개 더미데이터 생성")
-    void makeDummyData() {
-        List<User> users = userRepository.findAll();
-        List<News> newsList = newsRepository.findAll();
-        List<NewsHistory> newsHistories = new ArrayList<>();
-
-        for (long i = 0; i < 100000; i++) {
-            User user = users.get((int) (Math.random() * users.size()));
-            News news = newsList.get((int) (Math.random() * newsList.size()));
-
-            NewsHistory newsHistory = NewsHistory.builder()
-                    .user(user)
-                    .news(news)
-                    .isDummy(true)
-                    .build();
-            newsHistories.add(newsHistory);
-
-            if (newsHistories.size() % 1000 == 0) {
-                newsHistoryRepository.saveAll(newsHistories);
-                newsHistories.clear();
-            }
-        }
-
-        if (!newsHistories.isEmpty()) {
-            newsHistoryRepository.saveAll(newsHistories);
-        }
-    }
+    @Mock
+    AdminRepository adminRepository;
+    @InjectMocks
+    AdminNewsHistoryService adminNewsHistoryService;
 
     @Test
     @DisplayName("히스토리 조회 성공")
     public void successNewsHistoryRetrieve() {
-        StopWatch stopWatch = new StopWatch();
-        stopWatch.start();
-
-        // Given
+        //given
         Long userId = 1L;
-        Long newsId = 2L;
-        LocalDate createdAt = LocalDate.now();
+        LocalDate testDate = LocalDate.of(2020, 1, 1);
+        LocalDateTime testAt01 = LocalDateTime.of(2025, 1, 1, 0, 0, 0);
+        LocalDateTime testAt02 = LocalDateTime.of(2025, 1, 1, 23, 59, 59);
         int page = 0;
         int size = 20;
+
+        User user = User.builder()
+                .id(1L)
+                .kakaoEmail("kakao@kakao.com")
+                .build();
+
+        List<AdminNewsHistoryResponse> responses = List.of(
+                new AdminNewsHistoryResponse(
+                        1L,
+                        1L,
+                        1L,
+                        testAt01,
+                        testAt01
+                ),
+                new AdminNewsHistoryResponse(
+                        2L,
+                        2L,
+                        1L,
+                        testAt02,
+                        testAt02
+                )
+        );
+
         Pageable pageable = PageRequest.of(page, size);
+        Page<AdminNewsHistoryResponse> newsHistoryPage = new PageImpl<>(responses, pageable, responses.size());
 
-        // When
-        Page<AdminNewsHistoryResponse> newsHistories = newsHistoryRepository.findNewsHistoryListByCondition(userId, newsId, createdAt, pageable);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(adminRepository.existsByEmail(user.getKakaoEmail())).willReturn(true);
+        given(newsHistoryRepository.findNewsHistoryListByCondition(null, 1L, testDate, pageable)).willReturn(newsHistoryPage);
 
-        // Then
-        assertNotNull(newsHistories);
-        assertFalse(newsHistories.isEmpty());
-
-        stopWatch.stop();
-        System.out.println("걸린 시간: " + stopWatch.getTotalTimeMillis() + " ms");
-    }
-
-    @AfterEach
-    @DisplayName("더미데이터 삭제")
-    void deleteDummyData() {
-        newsHistoryRepository.deleteAllDummyData();
+        //when
+        Page<AdminNewsHistoryResponse> responsePage = adminNewsHistoryService.retrieveNewsHistory(userId, null, 1L, testDate, page, size);
+        assertEquals(2, responsePage.getContent().size());
+        assertEquals(1L, responsePage.getContent().get(0).userId());
+        assertEquals(2L, responsePage.getContent().get(1).userId());
+        assertEquals(page, responsePage.getNumber());
+        assertEquals(size, responsePage.getSize());
+        verify(newsHistoryRepository).findNewsHistoryListByCondition(null, 1L, testDate, pageable);
     }
 }

--- a/admin/src/test/java/itcast/AdminNewsHistoryServiceTest.java
+++ b/admin/src/test/java/itcast/AdminNewsHistoryServiceTest.java
@@ -39,7 +39,7 @@ public class AdminNewsHistoryServiceTest {
     AdminNewsHistoryService adminNewsHistoryService;
 
     @Test
-    @DisplayName("히스토리 조회 성공")
+    @DisplayName("뉴스 히스토리 조회 성공")
     public void successNewsHistoryRetrieve() {
         //given
         Long userId = 1L;
@@ -80,6 +80,8 @@ public class AdminNewsHistoryServiceTest {
 
         //when
         Page<AdminNewsHistoryResponse> responsePage = adminNewsHistoryService.retrieveNewsHistory(userId, null, 1L, testDate, page, size);
+
+        //then
         assertEquals(2, responsePage.getContent().size());
         assertEquals(1L, responsePage.getContent().get(0).userId());
         assertEquals(2L, responsePage.getContent().get(1).userId());

--- a/admin/src/test/java/itcast/AdminNewsServiceTest.java
+++ b/admin/src/test/java/itcast/AdminNewsServiceTest.java
@@ -160,7 +160,7 @@ public class AdminNewsServiceTest {
         Long userId = 1L;
         Long newsId = 1L;
         LocalDateTime fixedTime = LocalDateTime.of(2024, 12, 1, 12, 0);
-        LocalDate fixedDate2 = LocalDate.of(2024, 12, 1);
+        LocalDate fixedDate = LocalDate.of(2024, 12, 1);
 
         User user = User.builder()
                 .id(userId)
@@ -177,7 +177,7 @@ public class AdminNewsServiceTest {
                 .link("http://example.com")
                 .thumbnail("http://thumbnail.com")
                 .status(NewsStatus.SUMMARY)
-                .sendAt(sendAt)
+                .sendAt(fixedDate)
                 .build();
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));

--- a/common/src/main/java/itcast/domain/newsHistory/NewsHistory.java
+++ b/common/src/main/java/itcast/domain/newsHistory/NewsHistory.java
@@ -37,14 +37,9 @@ public class NewsHistory extends BaseEntity {
     @JoinColumn(name = "news_id")
     private News news;
 
-    @Column(name = "is_dummy", nullable = false)
-    private boolean isDummy;
-
-    //더미데이터 생성용 빌더
     @Builder
-    public NewsHistory(User user, News news, boolean isDummy) {
+    public NewsHistory(User user, News news) {
         this.user = user;
         this.news = news;
-        this.isDummy = isDummy;
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용
- 히스토리 테스트를 더미데이터 생성 방식에서 mock 테스트로 변경합니다

## ➕ 이슈 링크
- #111 

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/0557a3ed-e24e-46be-b436-5bda1db10a02)

## 🧑‍💻 예정 작업
- csv 파일 작업
## 📝 체크리스트
- [x] 브랜치 이름은 `issue/이슈번호` 형식으로 작성했는가?
- [x] 커밋 메시지는 `[#이슈번호] Feat: 커밋 내용` 형식으로 작성했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?