### PR TITLE
feat: 뉴스 히스토리 CSV 파일 다운로드 기능 구현

### DIFF
--- a/admin/build.gradle
+++ b/admin/build.gradle
@@ -27,6 +27,9 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+    //csv 작업
+    implementation 'com.opencsv:opencsv:5.9'
 }
 
 test {

--- a/admin/src/main/java/itcast/application/AdminNewsHistoryService.java
+++ b/admin/src/main/java/itcast/application/AdminNewsHistoryService.java
@@ -35,22 +35,22 @@ public class AdminNewsHistoryService {
         return newsHistoryRepository.findNewsHistoryListByCondition(userId, newsId, createdAt, pageable);
     }
 
-    public String createCsvFile(Long adminId) {
+    public String createCsvFile(Long adminId, Long userId, Long newsId, LocalDate startAt, LocalDate endAt) {
         isAdmin(adminId);
-        List<NewsHistory> newsHistoryList = newsHistoryRepository.findAll();
+        List<AdminNewsHistoryResponse> newsHistoryList = newsHistoryRepository.downloadNewsHistoryListByCondition(userId, newsId, startAt, endAt);
         StringWriter stringWriter = new StringWriter();
         CSVWriter csvWriter = new CSVWriter(stringWriter);
 
-        String[] header = new String[]{"id", "userId", "newsId", "createdAt", "updatedAt"};
+        String[] header = new String[]{"id", "userId", "newsId", "createdAt", "modifiedAt"};
         csvWriter.writeNext(header);
 
-        for (NewsHistory newsHistory : newsHistoryList) {
+        for (AdminNewsHistoryResponse response : newsHistoryList) {
             String[] data = {
-                    String.valueOf(newsHistory.getId()),
-                    String.valueOf(newsHistory.getUser().getId()),
-                    String.valueOf(newsHistory.getNews().getId()),
-                    String.valueOf(newsHistory.getCreatedAt()),
-                    String.valueOf(newsHistory.getModifiedAt())
+                    String.valueOf(response.id()),
+                    String.valueOf(response.userId()),
+                    String.valueOf(response.newsId()),
+                    String.valueOf(response.createdAt()),
+                    String.valueOf(response.modifiedAt())
             };
             csvWriter.writeNext(data);
         }

--- a/admin/src/main/java/itcast/application/AdminNewsHistoryService.java
+++ b/admin/src/main/java/itcast/application/AdminNewsHistoryService.java
@@ -1,5 +1,7 @@
 package itcast.application;
 
+import com.opencsv.CSVWriter;
+import itcast.domain.newsHistory.NewsHistory;
 import itcast.domain.user.User;
 import itcast.dto.response.AdminNewsHistoryResponse;
 import itcast.exception.ErrorCodes;
@@ -13,7 +15,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.io.StringWriter;
 import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +33,35 @@ public class AdminNewsHistoryService {
         isAdmin(adminId);
         Pageable pageable = PageRequest.of(page, size);
         return newsHistoryRepository.findNewsHistoryListByCondition(userId, newsId, createdAt, pageable);
+    }
+
+    public String createCsvFile(Long adminId) {
+        isAdmin(adminId);
+        List<NewsHistory> newsHistoryList = newsHistoryRepository.findAll();
+        StringWriter stringWriter = new StringWriter();
+        CSVWriter csvWriter = new CSVWriter(stringWriter);
+
+        String[] header = new String[]{"id", "userId", "newsId", "createdAt", "updatedAt"};
+        csvWriter.writeNext(header);
+
+        for (NewsHistory newsHistory : newsHistoryList) {
+            String[] data = {
+                    String.valueOf(newsHistory.getId()),
+                    String.valueOf(newsHistory.getUser().getId()),
+                    String.valueOf(newsHistory.getNews().getId()),
+                    String.valueOf(newsHistory.getCreatedAt()),
+                    String.valueOf(newsHistory.getModifiedAt())
+            };
+            csvWriter.writeNext(data);
+        }
+
+        try {
+            csvWriter.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return stringWriter.toString();
     }
 
     private void isAdmin(Long id) {

--- a/admin/src/main/java/itcast/controller/AdminNewsHistoryController.java
+++ b/admin/src/main/java/itcast/controller/AdminNewsHistoryController.java
@@ -9,7 +9,10 @@ import itcast.jwt.CheckAuth;
 import itcast.jwt.LoginMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -43,5 +46,20 @@ public class AdminNewsHistoryController {
                 newsHistoryPage.getTotalPages()
         );
         return new ResponseTemplate<>(HttpStatus.OK, "관리자 뉴스 히스토리 조회 성공", pageResponse);
+    }
+
+    @CheckAuth
+    @GetMapping("/download-csv")
+    public ResponseEntity<byte[]> downloadCsv(@LoginMember Long adminId) {
+        String csvContent = adminNewsHistoryService.createCsvFile(adminId);
+
+        // 파일 이름 설정
+        String fileName = "NewsHistory_File("+LocalDate.now()+").csv";
+
+        // HTTP 응답 생성
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + fileName)
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .body(csvContent.getBytes());
     }
 }

--- a/admin/src/main/java/itcast/controller/AdminNewsHistoryController.java
+++ b/admin/src/main/java/itcast/controller/AdminNewsHistoryController.java
@@ -50,8 +50,14 @@ public class AdminNewsHistoryController {
 
     @CheckAuth
     @GetMapping("/download-csv")
-    public ResponseEntity<byte[]> downloadCsv(@LoginMember Long adminId) {
-        String csvContent = adminNewsHistoryService.createCsvFile(adminId);
+    public ResponseEntity<byte[]> downloadCsv(
+            @LoginMember Long adminId,
+            @RequestParam(required = false) Long userId,
+            @RequestParam(required = false) Long newsId,
+            @RequestParam(required = false) LocalDate startAt,
+            @RequestParam(required = false) LocalDate endAt
+    ) {
+        String csvContent = adminNewsHistoryService.createCsvFile(adminId, userId, newsId, startAt, endAt);
 
         // 파일 이름 설정
         String fileName = "NewsHistory_File("+LocalDate.now()+").csv";

--- a/admin/src/main/java/itcast/repository/CustomNewsHistoryRepository.java
+++ b/admin/src/main/java/itcast/repository/CustomNewsHistoryRepository.java
@@ -1,11 +1,14 @@
 package itcast.repository;
 
+import itcast.domain.newsHistory.NewsHistory;
 import itcast.dto.response.AdminNewsHistoryResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public interface CustomNewsHistoryRepository {
     Page<AdminNewsHistoryResponse> findNewsHistoryListByCondition(Long userId, Long newsId, LocalDate createdAt, Pageable pageable);
+    List<AdminNewsHistoryResponse> downloadNewsHistoryListByCondition(Long userId, Long newsId, LocalDate startAt, LocalDate endAt);
 }

--- a/common/src/main/java/itcast/domain/newsHistory/NewsHistory.java
+++ b/common/src/main/java/itcast/domain/newsHistory/NewsHistory.java
@@ -42,4 +42,7 @@ public class NewsHistory extends BaseEntity {
         this.user = user;
         this.news = news;
     }
+
+    @Builder()
+    public NewsHistory(Long id, User user, News news) {}
 }


### PR DESCRIPTION
## 🔎 작업 내용
- CSV 파일을 해당 조건에 맞게 조회하여 다운로드합니다

## ➕ 이슈 링크
- #113

## 📸 스크린샷(선택
![뉴스 히스토리 다운로드 캡처](https://github.com/user-attachments/assets/4b2f7dbd-d284-4488-940d-3a225b1dc885)
![히스토리 저장캡처](https://github.com/user-attachments/assets/d456c0d0-755f-48cf-bf4e-04320806729e)
)

## 🧑‍💻 예정 작업
- 뉴스 히스토리 csv 파일 이메일 발송

## 📝 체크리스트
- [x] 브랜치 이름은 `issue/이슈번호` 형식으로 작성했는가?
- [x] 커밋 메시지는 `[#이슈번호] Feat: 커밋 내용` 형식으로 작성했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?