### PR TITLE
feat: 뉴스 히스토리 CSV 파일 메일 발송 구현

### DIFF
--- a/admin/build.gradle
+++ b/admin/build.gradle
@@ -28,8 +28,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
-    //csv 작업
     implementation 'com.opencsv:opencsv:5.9'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 test {

--- a/admin/src/main/java/itcast/application/AdminNewsHistoryService.java
+++ b/admin/src/main/java/itcast/application/AdminNewsHistoryService.java
@@ -1,7 +1,6 @@
 package itcast.application;
 
 import com.opencsv.CSVWriter;
-import itcast.domain.newsHistory.NewsHistory;
 import itcast.domain.user.User;
 import itcast.dto.response.AdminNewsHistoryResponse;
 import itcast.exception.ErrorCodes;
@@ -9,10 +8,15 @@ import itcast.exception.ItCastApplicationException;
 import itcast.jwt.repository.UserRepository;
 import itcast.repository.AdminRepository;
 import itcast.repository.NewsHistoryRepository;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 
 import java.io.StringWriter;
@@ -26,6 +30,7 @@ public class AdminNewsHistoryService {
     private final UserRepository userRepository;
     private final AdminRepository adminRepository;
     private final NewsHistoryRepository newsHistoryRepository;
+    private final JavaMailSender mailSender;
 
     public Page<AdminNewsHistoryResponse> retrieveNewsHistory(Long adminId, Long userId, Long newsId, LocalDate createdAt,
                                                               int page, int size
@@ -62,6 +67,24 @@ public class AdminNewsHistoryService {
         }
 
         return stringWriter.toString();
+    }
+
+    public void sendEmail(byte[] csvFile) throws MessagingException {
+        MimeMessage message = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+        String fileName = "NewsHistory_File(" + LocalDate.now() + ").csv";
+        String title = "[관리자 전용 발신] 뉴스 히스토리 CSV 파일";
+        String content = "첨부된 CSV 파일을 확인해주십시오.";
+        String to = "hamiwood@naver.com";
+
+        helper.setFrom("hamiwood@naver.com");
+        helper.setTo(to);
+        helper.setSubject(title);
+        helper.setText(content, false);
+
+        helper.addAttachment(fileName, new ByteArrayResource(csvFile));
+        mailSender.send(message);
     }
 
     private void isAdmin(Long id) {

--- a/admin/src/main/java/itcast/config/MailConfig.java
+++ b/admin/src/main/java/itcast/config/MailConfig.java
@@ -1,0 +1,34 @@
+package itcast.config;
+
+import itcast.dto.request.MailProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import java.util.Properties;
+
+@Configuration
+@RequiredArgsConstructor
+public class MailConfig {
+
+    private final MailProperties mailProperties;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(mailProperties.getHost());
+        mailSender.setPort(mailProperties.getPort());
+        mailSender.setUsername(mailProperties.getUsername());
+        mailSender.setPassword(mailProperties.getPassword());
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", String.valueOf(mailProperties.getProperties().isAuth()));
+        props.put("mail.smtp.ssl.enable", String.valueOf(mailProperties.getProperties().isSslEnable()));
+        props.put("mail.smtp.starttls.enable", String.valueOf(mailProperties.getProperties().isStarttlsEnable()));
+        props.put("mail.debug", "true");
+
+        return mailSender;
+    }
+}

--- a/admin/src/main/java/itcast/controller/AdminNewsHistoryController.java
+++ b/admin/src/main/java/itcast/controller/AdminNewsHistoryController.java
@@ -7,6 +7,7 @@ import itcast.dto.response.AdminNewsHistoryResponse;
 import itcast.dto.response.PageResponse;
 import itcast.jwt.CheckAuth;
 import itcast.jwt.LoginMember;
+import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpHeaders;
@@ -67,5 +68,19 @@ public class AdminNewsHistoryController {
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + fileName)
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
                 .body(csvContent.getBytes());
+    }
+
+    @CheckAuth
+    @GetMapping("/send-mail-csv")
+    public String sendMailCsv(
+            @LoginMember Long adminId,
+            @RequestParam(required = false) Long userId,
+            @RequestParam(required = false) Long newsId,
+            @RequestParam(required = false) LocalDate startAt,
+            @RequestParam(required = false) LocalDate endAt
+    ) throws MessagingException {
+        String csvFile = adminNewsHistoryService.createCsvFile(adminId, userId, newsId, startAt, endAt);
+        adminNewsHistoryService.sendEmail(csvFile.getBytes());
+        return "메일이 정상적으로 발송되었습니다";
     }
 }

--- a/admin/src/main/java/itcast/dto/request/MailProperties.java
+++ b/admin/src/main/java/itcast/dto/request/MailProperties.java
@@ -1,0 +1,26 @@
+package itcast.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "spring.mail")
+@Getter
+@Setter
+public class MailProperties {
+    private String host;
+    private int port;
+    private String username;
+    private String password;
+    private SmtpProperties properties = new SmtpProperties();
+
+    @Getter
+    @Setter
+    public static class SmtpProperties {
+        private boolean auth;
+        private boolean starttlsEnable;
+        private boolean sslEnable;
+    }
+}

--- a/admin/src/main/resources/application-prod.yml
+++ b/admin/src/main/resources/application-prod.yml
@@ -17,6 +17,23 @@ spring:
         show_sql: false
         format_sql: false
         dialect: org.hibernate.dialect.MySQLDialect
+
+  mail:
+    host: smtp.naver.com
+    port: 465
+    username: ${ADMIN_MAIL}
+    password: ${ADMIN_MAIL_PASSWORD}
+    properties:
+      mail:
+        transport:
+          protocol: smtp
+        smtp:
+          auth: true
+          starttls:
+            enable: false
+          ssl:
+            enable: true
+
 jwt:
   secret:
     key: ${JWT_SECRET_KEY}

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -13,6 +13,17 @@ spring:
       hibernate:
         format_sql: true
         use_sql_comments: true
+
+  mail:
+    host: smtp.naver.com
+    port: 465
+    username: ${ADMIN_MAIL}
+    password: ${ADMIN_MAIL_PASSWORD}
+    properties:
+      auth: true
+      starttlsEnable: false
+      sslEnable: true
+
   kakao:
     redirect-uri: http://localhost:8080/auth/kakao/callback
 


### PR DESCRIPTION
## 🔎 작업 내용
- 관리자가 조건에 따라 생성된 뉴스 히스토리 csv 파일을 메일로 받습니다.

## ➕ 이슈 링크
- #120 

## 📸 스크린샷(선택)
![관리자 메일발송](https://github.com/user-attachments/assets/5d9ebc33-201e-4237-b455-649db1ce866f)

## 🧑‍💻 예정 작업
- 관리자 블로그 히스토리 csv파일 메일 전송
## 📝 체크리스트
- [x] 브랜치 이름은 `issue/이슈번호` 형식으로 작성했는가?
- [x] 커밋 메시지는 `[#이슈번호] Feat: 커밋 내용` 형식으로 작성했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?