### PR TITLE
feat: 메일 실패시 재발송 로직 및 MailEvents에 저장 기능 구현

### DIFF
--- a/common/src/main/java/itcast/domain/mailEvent/MailEvents.java
+++ b/common/src/main/java/itcast/domain/mailEvent/MailEvents.java
@@ -1,8 +1,6 @@
 package itcast.domain.mailEvent;
 
 import itcast.domain.BaseEntity;
-import itcast.domain.blog.Blog;
-import itcast.domain.news.News;
 import itcast.domain.user.User;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -28,11 +26,35 @@ public class MailEvents extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "blog_id")
-    private Blog blog;
+    private String title;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "news_id")
-    private News news;
+    private String summary;
+
+    private String originalLink;
+
+    private String thumbnail;
+
+    private MailEvents(
+            final User user,
+            final String title,
+            final String summary,
+            final String originalLink,
+            final String thumbnail
+    ) {
+        this.user = user;
+        this.title = title;
+        this.summary = summary;
+        this.originalLink = originalLink;
+        this.thumbnail = thumbnail;
+    }
+
+    public static MailEvents of(
+            final User user,
+            final String title,
+            final String summary,
+            final String originalLink,
+            final String thumbnail
+    ) {
+        return new MailEvents(user, title, summary, originalLink, thumbnail);
+    }
 }

--- a/common/src/main/java/itcast/mail/application/MailService.java
+++ b/common/src/main/java/itcast/mail/application/MailService.java
@@ -7,7 +7,6 @@ import com.amazonaws.services.simpleemail.model.SendEmailRequest;
 import itcast.domain.mailEvent.MailEvents;
 import itcast.domain.user.User;
 import itcast.jwt.repository.UserRepository;
-import itcast.mail.dto.request.MailContent;
 import itcast.mail.dto.request.SendMailRequest;
 import itcast.mail.dto.request.SendValidateMailRequest;
 import itcast.mail.repository.MailEventsRepository;
@@ -58,17 +57,16 @@ public class MailService {
             } catch (MessageRejectedException ex) {
                 log.error("메일 재발송에 실패하였습니다. {}", receiver, ex);
                 final User user = userRepository.findByEmail(receiver);
-
-                for (MailContent mailContent : sendMailRequest.contents()) {
-                    final MailEvents mailEvent = MailEvents.of(
-                            user,
-                            mailContent.title(),
-                            mailContent.summary(),
-                            mailContent.originalLink(),
-                            mailContent.thumbnail()
-                    );
-                    mailEventsRepository.save(mailEvent);
-                }
+                sendMailRequest.contents()
+                        .stream()
+                        .map(mailContent -> MailEvents.of(
+                                user,
+                                mailContent.title(),
+                                mailContent.summary(),
+                                mailContent.originalLink(),
+                                mailContent.thumbnail()
+                        ))
+                        .forEach(mailEventsRepository::save);
             }
         }
     }

--- a/common/src/main/java/itcast/mail/application/MailService.java
+++ b/common/src/main/java/itcast/mail/application/MailService.java
@@ -2,11 +2,19 @@ package itcast.mail.application;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
+import com.amazonaws.services.simpleemail.model.MessageRejectedException;
 import com.amazonaws.services.simpleemail.model.SendEmailRequest;
-import itcast.mail.sender.EmailSender;
-import itcast.mail.sender.EmailValidatorSender;
+import itcast.domain.mailEvent.MailEvents;
+import itcast.domain.user.User;
+import itcast.jwt.repository.UserRepository;
+import itcast.mail.dto.request.MailContent;
 import itcast.mail.dto.request.SendMailRequest;
 import itcast.mail.dto.request.SendValidateMailRequest;
+import itcast.mail.repository.MailEventsRepository;
+import itcast.mail.sender.EmailSender;
+import itcast.mail.sender.EmailValidatorSender;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -20,14 +28,48 @@ public class MailService {
     private final AmazonSimpleEmailService amazonSimpleEmailService;
     private final EmailSender emailSender;
     private final EmailValidatorSender emailValidatorSender;
+    private final MailEventsRepository mailEventsRepository;
+    private final UserRepository userRepository;
 
     @Async("taskExecutor")
     public void send(final SendMailRequest sendMailRequest) {
-        try {
-            final SendEmailRequest emailRequest = emailSender.from(sendMailRequest);
-            amazonSimpleEmailService.sendEmail(emailRequest);
-        } catch (Exception ex) {
-            throw new AmazonClientException(ex.getMessage(), ex);
+        final List<String> failedReceivers = new ArrayList<>();
+
+        for (String receiver : sendMailRequest.receivers()) {
+            try {
+                final SendEmailRequest emailRequest = emailSender.from(sendMailRequest, receiver);
+                amazonSimpleEmailService.sendEmail(emailRequest);
+            } catch (Exception ex) {
+                failedReceivers.add(receiver);
+                log.error("메일 발송에 실패하였습니다. {}", receiver, ex);
+            }
+        }
+
+        if (!failedReceivers.isEmpty()) {
+            retryFailedEmails(failedReceivers, sendMailRequest);
+        }
+    }
+
+    private void retryFailedEmails(final List<String> failedReceivers, final SendMailRequest sendMailRequest) {
+        for (String receiver : failedReceivers) {
+            try {
+                final SendEmailRequest emailRequest = emailSender.from(sendMailRequest, receiver);
+                amazonSimpleEmailService.sendEmail(emailRequest);
+            } catch (MessageRejectedException ex) {
+                log.error("메일 재발송에 실패하였습니다. {}", receiver, ex);
+                final User user = userRepository.findByEmail(receiver);
+
+                for (MailContent mailContent : sendMailRequest.contents()) {
+                    final MailEvents mailEvent = MailEvents.of(
+                            user,
+                            mailContent.title(),
+                            mailContent.summary(),
+                            mailContent.originalLink(),
+                            mailContent.thumbnail()
+                    );
+                    mailEventsRepository.save(mailEvent);
+                }
+            }
         }
     }
 

--- a/common/src/main/java/itcast/mail/repository/MailEventsRepository.java
+++ b/common/src/main/java/itcast/mail/repository/MailEventsRepository.java
@@ -1,0 +1,7 @@
+package itcast.mail.repository;
+
+import itcast.domain.mailEvent.MailEvents;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MailEventsRepository extends JpaRepository<MailEvents, Long> {
+}

--- a/common/src/main/java/itcast/mail/sender/EmailSender.java
+++ b/common/src/main/java/itcast/mail/sender/EmailSender.java
@@ -25,9 +25,9 @@ public class EmailSender {
 
     private final TemplateEngine templateEngine;
 
-    public SendEmailRequest from(final SendMailRequest request) {
+    public SendEmailRequest from(final SendMailRequest request, final String receiver) {
         final Destination destination = new Destination()
-                .withToAddresses(request.receivers());
+                .withToAddresses(receiver);
 
         final Message message = new Message()
                 .withSubject(createContent(String.format(MAIL_SUBJECT)))


### PR DESCRIPTION
## 🔎 작업 내용
- 메일 실패시 재발송 로직 및 MailEvents에 저장 기능 구현

## ➕ 이슈 링크
- #125 