### PR TITLE
feat: 관리자 메일 조회 구현

### DIFF
--- a/admin/src/main/java/itcast/application/AdminCheckService.java
+++ b/admin/src/main/java/itcast/application/AdminCheckService.java
@@ -1,0 +1,26 @@
+package itcast.application;
+
+import itcast.domain.user.User;
+import itcast.exception.ErrorCodes;
+import itcast.exception.ItCastApplicationException;
+import itcast.jwt.repository.UserRepository;
+import itcast.repository.AdminRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminCheckService {
+
+    private final UserRepository userRepository;
+    private final AdminRepository adminRepository;
+
+    public void isAdmin(Long id) {
+        User user = userRepository.findById(id).orElseThrow(() ->
+                new ItCastApplicationException(ErrorCodes.USER_NOT_FOUND));
+        String email = user.getKakaoEmail();
+        if (!adminRepository.existsByEmail(email)) {
+            throw new ItCastApplicationException(ErrorCodes.INVALID_USER);
+        }
+    }
+}

--- a/admin/src/main/java/itcast/application/AdminMailService.java
+++ b/admin/src/main/java/itcast/application/AdminMailService.java
@@ -2,7 +2,7 @@ package itcast.application;
 
 import itcast.domain.mailEvent.MailEvents;
 import itcast.dto.response.MailResponse;
-import itcast.repository.MailRepository;
+import itcast.mail.repository.MailEventsRepository;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.data.domain.Page;
@@ -20,13 +20,13 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class AdminMailService {
 
-    private final MailRepository mailRepository;
+    private final MailEventsRepository mailEventsRepository;
     private final AdminCheckService adminCheckService;
 
     public Page<MailResponse> retrieveMailEvent(Long adminId, int page, int size) {
         adminCheckService.isAdmin(adminId);
         PageRequest pageable = PageRequest.of(page, size);
-        Page<MailEvents> mailEventsPage = mailRepository.findAll(pageable);
+        Page<MailEvents> mailEventsPage = mailEventsRepository.findAll(pageable);
 
         Map<Pair<Long, LocalDate>, List<MailResponse.MailContent>> groupedData = mailEventsPage.getContent().stream()
                 .collect(Collectors.groupingBy(

--- a/admin/src/main/java/itcast/application/AdminMailService.java
+++ b/admin/src/main/java/itcast/application/AdminMailService.java
@@ -1,0 +1,58 @@
+package itcast.application;
+
+import itcast.domain.mailEvent.MailEvents;
+import itcast.dto.response.MailResponse;
+import itcast.repository.MailRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AdminMailService {
+
+    private final MailRepository mailRepository;
+    private final AdminCheckService adminCheckService;
+
+    public Page<MailResponse> retrieveMailEvent(Long adminId, int page, int size) {
+        adminCheckService.isAdmin(adminId);
+        PageRequest pageable = PageRequest.of(page, size);
+        Page<MailEvents> mailEventsPage = mailRepository.findAll(pageable);
+
+        Map<Long, Map<LocalDate, List<MailResponse.MailContent>>> groupedData = mailEventsPage.getContent().stream()
+                .collect(Collectors.groupingBy(
+                        event -> event.getUser().getId(),
+                        Collectors.groupingBy(
+                                event -> event.getCreatedAt().toLocalDate(),
+                                Collectors.mapping(
+                                        event -> new MailResponse.MailContent(
+                                                event.getId(),
+                                                event.getTitle(),
+                                                event.getSummary(),
+                                                event.getOriginalLink(),
+                                                event.getThumbnail()
+                                        ),
+                                        Collectors.toList()
+                                )
+                        )
+                ));
+
+        List<MailResponse> mailResponses = groupedData.entrySet().stream()
+                .flatMap(userEntry -> userEntry.getValue().entrySet().stream()
+                        .map(dateEntry -> new MailResponse(
+                                userEntry.getKey(),
+                                dateEntry.getKey(),
+                                dateEntry.getValue()
+                        )))
+                .collect(Collectors.toList());
+
+        return new PageImpl<>(mailResponses, pageable, mailEventsPage.getTotalElements());
+    }
+}

--- a/admin/src/main/java/itcast/application/AdminMailService.java
+++ b/admin/src/main/java/itcast/application/AdminMailService.java
@@ -52,7 +52,7 @@ public class AdminMailService {
                 .sorted(Comparator
                         .comparing(MailResponse::createdAt, Comparator.reverseOrder())
                         .thenComparing(MailResponse::userId))
-                .collect(Collectors.toList());
+                .toList();
 
         return new PageImpl<>(mailResponses, pageable, mailEventsPage.getTotalElements());
     }

--- a/admin/src/main/java/itcast/controller/AdminMailController.java
+++ b/admin/src/main/java/itcast/controller/AdminMailController.java
@@ -1,0 +1,40 @@
+package itcast.controller;
+
+import itcast.ResponseTemplate;
+import itcast.application.AdminMailService;
+import itcast.dto.response.MailResponse;
+import itcast.dto.response.PageResponse;
+import itcast.jwt.CheckAuth;
+import itcast.jwt.LoginMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/mail-event")
+public class AdminMailController {
+
+    private final AdminMailService adminMailService;
+
+    @CheckAuth
+    @GetMapping
+    public ResponseTemplate<PageResponse<MailResponse>> retrieveMailEvent(
+            @LoginMember Long adminId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Page<MailResponse> mailPage = adminMailService.retrieveMailEvent(adminId, page, size);
+        PageResponse<MailResponse> pageResponse = new PageResponse<>(
+                mailPage.getContent(),
+                mailPage.getNumber(),
+                mailPage.getSize(),
+                mailPage.getTotalPages()
+        );
+        return new ResponseTemplate<>(HttpStatus.OK, "메일 이벤트 조회 성공", pageResponse);
+    }
+}

--- a/admin/src/main/java/itcast/dto/response/MailResponse.java
+++ b/admin/src/main/java/itcast/dto/response/MailResponse.java
@@ -1,0 +1,18 @@
+package itcast.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record MailResponse(
+        Long userId,
+        LocalDate createdAt,
+        List<MailContent> contents
+) {
+    public record MailContent(
+            Long id,
+            String title,
+            String summary,
+            String originalLink,
+            String thumbnail
+    ) {}
+}

--- a/admin/src/main/java/itcast/repository/MailRepository.java
+++ b/admin/src/main/java/itcast/repository/MailRepository.java
@@ -1,7 +1,0 @@
-package itcast.repository;
-
-import itcast.domain.mailEvent.MailEvents;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface MailRepository extends JpaRepository<MailEvents, Long> {
-}

--- a/admin/src/main/java/itcast/repository/MailRepository.java
+++ b/admin/src/main/java/itcast/repository/MailRepository.java
@@ -1,0 +1,7 @@
+package itcast.repository;
+
+import itcast.domain.mailEvent.MailEvents;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MailRepository extends JpaRepository<MailEvents, Long> {
+}

--- a/admin/src/main/resources/templates/email-template.html
+++ b/admin/src/main/resources/templates/email-template.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>News letter</title>
+</head>
+<body style="font-family: Arial, sans-serif;
+            background-color: #f8f9fa;
+            margin: 0;
+            padding: 0;
+            text-align: center;
+            color: #333;">
+<div class="container" style="max-width: 640px;
+            margin: 20px auto;
+            background: #fff;
+            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+            border-radius: 10px;
+            overflow: hidden;
+            border: 1px solid #ddd;">
+
+    <div class="header" style="background-color: #ffffff;
+            padding: 20px;
+            border-bottom: 1px solid #ddd;
+            text-align: center;">
+        <img src="https://travel-spring.s3.ap-northeast-2.amazonaws.com/it-cast-logo.png" alt="Logo" style="max-width: 120px;
+            margin-bottom: 10px;">
+        <h1 style="font-size: 24px;
+            margin: 10px 0 5px;
+            color: #333;
+            font-weight: bold;">It-Cast &#45684;&#49828;&#47112;&#53552;</h1>
+        <p style="font-size: 14px;
+            color: #777;
+            margin: 0;">&#52572;&#49888; IT &#52968;&#53584;&#52768;&#47484; &#48372;&#45236;&#46300;&#47549;&#45768;&#45796;.</p>
+    </div>
+
+    <div class="content" th:each="content : ${contents}" style="padding: 20px;">
+        <div class="content-item" style="margin-bottom: 30px;
+            text-align: center;">
+            <img th:src="${content.thumbnail}" alt="Thumbnail" style="max-width: 100%;
+            height: auto;
+            border-radius: 10px;
+            margin-bottom: 10px;">
+            <h2 th:text="${content.title}" style="font-size: 18px;
+            color: #333;
+            margin: 10px 0;"></h2>
+            <p th:text="${content.summary}" style="font-size: 14px;
+            line-height: 1.6;
+            color: #555;
+            margin-bottom: 10px;"></p>
+            <a th:href="${content.originalLink}" target="_blank" style="display: inline-block;
+            font-size: 14px;
+            color: #0073e6;
+            font-weight: bold;
+            text-decoration: none;
+            margin-top: 5px;
+            padding: 8px 15px;
+            border: 1px solid #0073e6;
+            border-radius: 5px;">&#51088;&#49464;&#55176; &#48372;&#44592;</a>
+        </div>
+    </div>
+
+    <div class="footer" style="background-color: #f2f2f2;
+            padding: 15px;
+            font-size: 12px;
+            color: #888;
+            border-top: 1px solid #ddd;">
+        &copy; 2024 IT News Digest. All rights reserved.
+    </div>
+</div>
+</body>
+</html>

--- a/admin/src/test/java/itcast/AdminMailServiceTest.java
+++ b/admin/src/test/java/itcast/AdminMailServiceTest.java
@@ -5,7 +5,7 @@ import itcast.application.AdminMailService;
 import itcast.domain.mailEvent.MailEvents;
 import itcast.domain.user.User;
 import itcast.dto.response.MailResponse;
-import itcast.repository.MailRepository;
+import itcast.mail.repository.MailEventsRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,8 +16,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
@@ -27,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class AdminMailServiceTest {
 
     @Mock
-    private MailRepository mailRepository;
+    private MailEventsRepository mailEventsRepository;
 
     @Mock
     private AdminCheckService adminCheckService;
@@ -64,7 +62,7 @@ class AdminMailServiceTest {
         List<MailEvents> mailEventsList = Arrays.asList(event1, event2);
         Page<MailEvents> mailEventsPage = new PageImpl<>(mailEventsList, pageable, mailEventsList.size());
 
-        when(mailRepository.findAll(pageable)).thenReturn(mailEventsPage);
+        when(mailEventsRepository.findAll(pageable)).thenReturn(mailEventsPage);
         doNothing().when(adminCheckService).isAdmin(adminId);
 
         // When
@@ -72,7 +70,7 @@ class AdminMailServiceTest {
 
         // Then
         verify(adminCheckService).isAdmin(adminId);
-        verify(mailRepository).findAll(pageable);
+        verify(mailEventsRepository).findAll(pageable);
 
         // 검증 로직 수정
         assertEquals(2, result.getContent().size());

--- a/admin/src/test/java/itcast/AdminMailServiceTest.java
+++ b/admin/src/test/java/itcast/AdminMailServiceTest.java
@@ -1,0 +1,102 @@
+package itcast;
+
+import itcast.application.AdminCheckService;
+import itcast.application.AdminMailService;
+import itcast.domain.mailEvent.MailEvents;
+import itcast.domain.user.User;
+import itcast.dto.response.MailResponse;
+import itcast.repository.MailRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AdminMailServiceTest {
+
+    @Mock
+    private MailRepository mailRepository;
+
+    @Mock
+    private AdminCheckService adminCheckService;
+
+    @InjectMocks
+    private AdminMailService adminMailService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("메일 조회 성공 테스트")
+    void SuccessRetrieveMailEvents() {
+        // Given
+        Long adminId = 1L;
+        int page = 0;
+        int size = 10;
+        PageRequest pageable = PageRequest.of(page, size);
+
+        User user1 = User.builder()
+                .id(1L)
+                .kakaoEmail("kakao@kakao.com")
+                .build();
+        User user2 = User.builder()
+                .id(2L)
+                .kakaoEmail("kakao@kakao.com")
+                .build();
+
+        MailEvents event1 = MailEvents.of(user1, "제목1", "요약1", "링크1", "썸네일1");
+        MailEvents event2 = MailEvents.of(user2, "제목2", "요약2", "링크2", "썸네일2");
+
+        setPrivateField(event1, "id", 1L);
+        setPrivateField(event2, "id", 2L);
+
+        List<MailEvents> mailEventsList = Arrays.asList(event1, event2);
+        Page<MailEvents> mailEventsPage = new PageImpl<>(mailEventsList, pageable, mailEventsList.size());
+
+        when(mailRepository.findAll(pageable)).thenReturn(mailEventsPage);
+        doNothing().when(adminCheckService).isAdmin(adminId);
+
+        // When
+        Page<MailResponse> result = adminMailService.retrieveMailEvent(adminId, page, size);
+
+        // Then
+        verify(adminCheckService).isAdmin(adminId);
+        verify(mailRepository).findAll(pageable);
+
+        // 검증 로직 수정
+        assertEquals(2, result.getContent().size());
+
+        MailResponse response1 = result.getContent().get(0);
+        assertEquals(1L, response1.userId());
+        assertEquals(1, response1.contents().size());
+
+        MailResponse response2 = result.getContent().get(1);
+        assertEquals(2L, response2.userId());
+        assertEquals(1, response2.contents().size());
+    }
+
+    private void setPrivateField(Object object, String fieldName, Object value) {
+        try {
+            java.lang.reflect.Field field = object.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(object, value);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/admin/src/test/java/itcast/AdminMailServiceTest.java
+++ b/admin/src/test/java/itcast/AdminMailServiceTest.java
@@ -61,9 +61,6 @@ class AdminMailServiceTest {
         MailEvents event1 = MailEvents.of(user1, "제목1", "요약1", "링크1", "썸네일1");
         MailEvents event2 = MailEvents.of(user2, "제목2", "요약2", "링크2", "썸네일2");
 
-        setPrivateField(event1, "id", 1L);
-        setPrivateField(event2, "id", 2L);
-
         List<MailEvents> mailEventsList = Arrays.asList(event1, event2);
         Page<MailEvents> mailEventsPage = new PageImpl<>(mailEventsList, pageable, mailEventsList.size());
 
@@ -88,15 +85,4 @@ class AdminMailServiceTest {
         assertEquals(2L, response2.userId());
         assertEquals(1, response2.contents().size());
     }
-
-    private void setPrivateField(Object object, String fieldName, Object value) {
-        try {
-            java.lang.reflect.Field field = object.getClass().getDeclaredField(fieldName);
-            field.setAccessible(true);
-            field.set(object, value);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            e.printStackTrace();
-        }
-    }
-
 }


### PR DESCRIPTION
## 🔎 작업 내용
- 실패한 메일을 createdAt과 userId로 그룹화하여 조회합니다.

## ➕ 이슈 링크
- #124 

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/990083d7-f247-4834-97f5-5f8f458cc0bd)

## 🧑‍💻 예정 작업
- 실패한 메일 전송
## 📝 체크리스트
- [x] 브랜치 이름은 `issue/이슈번호` 형식으로 작성했는가?
- [x] 커밋 메시지는 `[#이슈번호] Feat: 커밋 내용` 형식으로 작성했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?