### PR TITLE
feat: 메일 재 발송 실패 시 Slack 알림 구축

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -29,6 +29,11 @@ dependencies {
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+    // slack
+    implementation "com.slack.api:bolt:1.18.0"
+    implementation "com.slack.api:bolt-servlet:1.18.0"
+    implementation "com.slack.api:bolt-jetty:1.18.0"
 }
 
 test {

--- a/common/src/main/java/itcast/exception/ErrorCodes.java
+++ b/common/src/main/java/itcast/exception/ErrorCodes.java
@@ -43,6 +43,9 @@ public enum ErrorCodes {
     MAIL_AUTH_CODE_EXPIRED("인증 코드가 만료되었습니다.", 6001L, HttpStatus.BAD_REQUEST),
     MAIL_AUTH_CODE_MISMATCH("인증 코드가 일치하지 않습니다.", 6002L, HttpStatus.FORBIDDEN),
 
+    // Slack
+    SLACK_PARSE_ERROR("슬랙 알림에 실패했습니다.",7001L, HttpStatus.BAD_REQUEST),
+
     BAD_REQUEST("BAD_REQUEST", 9404L, HttpStatus.BAD_REQUEST),
     BAD_REQUEST_JSON_PARSE_ERROR("[BAD_REQUEST] JSON_PARSE_ERROR - 올바른 JSON 형식이 아님", 9405L, HttpStatus.BAD_REQUEST),
     INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", 9999L, HttpStatus.INTERNAL_SERVER_ERROR);

--- a/common/src/main/java/itcast/mail/application/MailService.java
+++ b/common/src/main/java/itcast/mail/application/MailService.java
@@ -29,6 +29,7 @@ public class MailService {
     private final EmailValidatorSender emailValidatorSender;
     private final MailEventsRepository mailEventsRepository;
     private final UserRepository userRepository;
+    private final SlackService slackService;
 
     @Async("taskExecutor")
     public void send(final SendMailRequest sendMailRequest) {
@@ -67,6 +68,7 @@ public class MailService {
                                 mailContent.thumbnail()
                         ))
                         .forEach(mailEventsRepository::save);
+                slackService.postInquiry(receiver);
             }
         }
     }

--- a/common/src/main/java/itcast/mail/application/MailService.java
+++ b/common/src/main/java/itcast/mail/application/MailService.java
@@ -9,11 +9,14 @@ import itcast.domain.user.User;
 import itcast.jwt.repository.UserRepository;
 import itcast.mail.dto.request.SendMailRequest;
 import itcast.mail.dto.request.SendValidateMailRequest;
+import itcast.mail.dto.request.SlackRequestDto;
 import itcast.mail.repository.MailEventsRepository;
 import itcast.mail.sender.EmailSender;
 import itcast.mail.sender.EmailValidatorSender;
+
 import java.util.ArrayList;
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;

--- a/common/src/main/java/itcast/mail/application/SlackService.java
+++ b/common/src/main/java/itcast/mail/application/SlackService.java
@@ -29,11 +29,11 @@ public class SlackService {
     @Value("${slack.channel.monitor}")
     private String channel;
 
-    public void postInquiry(SlackRequestDto slackRequestDto) {
+    public void postInquiry(String receiver) {
         try {
             List<TextObject> textObjects = new ArrayList<>();
             textObjects.add(markdownText("*재 발송 실패 날짜:*\n" + LocalDateTime.now()));
-            textObjects.add(markdownText("*재 시도 실패 메일:*\n" + slackRequestDto.receiver()));
+            textObjects.add(markdownText("*재 시도 실패 메일:*\n" + receiver));
 
             MethodsClient methods = Slack.getInstance().methods(token);
             ChatPostMessageRequest request = ChatPostMessageRequest.builder()

--- a/common/src/main/java/itcast/mail/application/SlackService.java
+++ b/common/src/main/java/itcast/mail/application/SlackService.java
@@ -3,8 +3,10 @@ package itcast.mail.application;
 import com.slack.api.Slack;
 import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.methods.response.chat.ChatPostMessageResponse;
 import com.slack.api.model.block.composition.TextObject;
 import itcast.exception.ItCastApplicationException;
+import itcast.mail.dto.request.SlackRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -22,18 +24,20 @@ import static itcast.exception.ErrorCodes.SLACK_PARSE_ERROR;
 @RequiredArgsConstructor
 public class SlackService {
 
-    private static final String TOKEN = "token";
-    private static final String CHANNEL = "channel";
+    @Value("${slack.token}")
+    private String token;
+    @Value("${slack.channel.monitor}")
+    private String channel;
 
-    public void postInquiry(String receiver) {
+    public void postInquiry(SlackRequestDto slackRequestDto) {
         try {
             List<TextObject> textObjects = new ArrayList<>();
             textObjects.add(markdownText("*재 발송 실패 날짜:*\n" + LocalDateTime.now()));
-            textObjects.add(markdownText("*재 시도 실패 메일:*\n" +receiver));
+            textObjects.add(markdownText("*재 시도 실패 메일:*\n" + slackRequestDto.receiver()));
 
-            MethodsClient methods = Slack.getInstance().methods(TOKEN);
+            MethodsClient methods = Slack.getInstance().methods(token);
             ChatPostMessageRequest request = ChatPostMessageRequest.builder()
-                    .channel(CHANNEL)
+                    .channel(channel)
                     .blocks(asBlocks(
                             header(header ->
                                     header.text(plainText("메일 재 발송에 실패 했습니다!!!"))),
@@ -42,8 +46,13 @@ public class SlackService {
                                     section.fields(textObjects)
                             ))).build();
 
-            methods.chatPostMessage(request);
+            ChatPostMessageResponse response = methods.chatPostMessage(request);
+            if (!response.isOk()) {
+                System.err.println("Slack API Error: " + response.getError());
+                throw new ItCastApplicationException(SLACK_PARSE_ERROR);
+            }
         } catch (Exception e) {
+            System.err.println("Error posting message to Slack: " + e.getMessage());
             throw new ItCastApplicationException(SLACK_PARSE_ERROR);
         }
     }

--- a/common/src/main/java/itcast/mail/application/SlackService.java
+++ b/common/src/main/java/itcast/mail/application/SlackService.java
@@ -22,10 +22,8 @@ import static itcast.exception.ErrorCodes.SLACK_PARSE_ERROR;
 @RequiredArgsConstructor
 public class SlackService {
 
-    @Value(value = "${slack.token}")
-    private String token;
-    @Value(value = "${slack.channel.monitor}")
-    private String channel;
+    private static final String TOKEN = "token";
+    private static final String CHANNEL = "channel";
 
     public void postInquiry(String receiver) {
         try {
@@ -33,9 +31,9 @@ public class SlackService {
             textObjects.add(markdownText("*재 발송 실패 날짜:*\n" + LocalDateTime.now()));
             textObjects.add(markdownText("*재 시도 실패 메일:*\n" +receiver));
 
-            MethodsClient methods = Slack.getInstance().methods(token);
+            MethodsClient methods = Slack.getInstance().methods(TOKEN);
             ChatPostMessageRequest request = ChatPostMessageRequest.builder()
-                    .channel(channel)
+                    .channel(CHANNEL)
                     .blocks(asBlocks(
                             header(header ->
                                     header.text(plainText("메일 재 발송에 실패 했습니다!!!"))),

--- a/common/src/main/java/itcast/mail/application/SlackService.java
+++ b/common/src/main/java/itcast/mail/application/SlackService.java
@@ -1,0 +1,52 @@
+package itcast.mail.application;
+
+import com.slack.api.Slack;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.model.block.composition.TextObject;
+import itcast.exception.ItCastApplicationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.slack.api.model.block.Blocks.*;
+import static com.slack.api.model.block.composition.BlockCompositions.markdownText;
+import static com.slack.api.model.block.composition.BlockCompositions.plainText;
+import static itcast.exception.ErrorCodes.SLACK_PARSE_ERROR;
+
+@Service
+@RequiredArgsConstructor
+public class SlackService {
+
+    @Value(value = "${slack.token}")
+    private String token;
+    @Value(value = "${slack.channel.monitor}")
+    private String channel;
+
+    public void postInquiry(String receiver) {
+        try {
+            List<TextObject> textObjects = new ArrayList<>();
+            textObjects.add(markdownText("*재 발송 실패 날짜:*\n" + LocalDateTime.now()));
+            textObjects.add(markdownText("*재 시도 실패 메일:*\n" +receiver));
+
+            MethodsClient methods = Slack.getInstance().methods(token);
+            ChatPostMessageRequest request = ChatPostMessageRequest.builder()
+                    .channel(channel)
+                    .blocks(asBlocks(
+                            header(header ->
+                                    header.text(plainText("메일 재 발송에 실패 했습니다!!!"))),
+                            divider(),
+                            section(section ->
+                                    section.fields(textObjects)
+                            ))).build();
+
+            methods.chatPostMessage(request);
+        } catch (Exception e) {
+            throw new ItCastApplicationException(SLACK_PARSE_ERROR);
+        }
+    }
+}

--- a/schedule/src/main/java/itcast/news/application/NewsService.java
+++ b/schedule/src/main/java/itcast/news/application/NewsService.java
@@ -72,9 +72,6 @@ public class NewsService {
             LocalDateTime publishedAt = convertDateTime(date);
 
             if (thumbnail.isEmpty()) {
-                throw new ItCastApplicationException(INVALID_NEWS_CONTENT);
-            }
-            if (thumbnail.isEmpty()) {
                 log.error("썸네일이 존재하지 않습니다. {}", link);
                 throw new ItCastApplicationException(INVALID_NEWS_CONTENT);
             }


### PR DESCRIPTION
## 🔎 작업 내용
-  메일 재 발송 실패 시 Slack 알림 구축
-  실패한 시간과 실패한 메일을 알림

## ➕ 이슈 링크
- #103

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/97091c83-c303-450e-9b65-375628bcc303)

## 📝 체크리스트
- [ ] 브랜치 이름은 `issue/이슈번호` 형식으로 작성했는가?
- [ ] 커밋 메시지는 `[#이슈번호] Feat: 커밋 내용` 형식으로 작성했는가?
- [ ] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [ ] 테스트를 진행했는가?
- [ ] 테스트 코드를 작성했는가?